### PR TITLE
:recycle: [수정] Callable을 import 하는 부분을 수정하였습니다.

### DIFF
--- a/Chapter_3/ch03_ex1.py
+++ b/Chapter_3/ch03_ex1.py
@@ -4,9 +4,12 @@
 Chapter 3, Example Set 1
 """
 import timeit
-import collections
+try:
+    from collections import Callable
+except ImportError as e:
+    from collections.abc import Callable
 
-class Mersenne1( collections.Callable ):
+class Mersenne1( Callable ):
     """Callable object with a **Strategy** plug in required."""
     def __init__( self, algorithm ):
         self.pow2= algorithm
@@ -50,7 +53,7 @@ m1f= Mersenne1( faster )
 # Alternative Mersenne using class-level configuration.
 # The syntax is awkward.
 
-class Mersenne2( collections.Callable ):
+class Mersenne2( Callable ):
     pow2= None
     def __call__( self, arg ):
         pow2= self.__class__.__dict__['pow2']


### PR DESCRIPTION
python 3.3 에서는 `from collections import Callable` 이 가능합니다.
python 3.4 부터는 `from collections.abc import Callable` 만 가능하고 이전 Callable은 오류를 발생시킵니다.

책에서 python 3.3 / 3.4 를 실습환경으로 설정했기에 import를 두가지 방식 모두 가능하게 하는 것이 좋을 것 같아서 수정하였습니다.